### PR TITLE
fix: extend parser definition in parserOptions

### DIFF
--- a/src/parser-options.d.ts
+++ b/src/parser-options.d.ts
@@ -250,7 +250,7 @@ export interface ParserOptions extends Partial<Record<string, unknown>> {
    * @see [Working with Custom Parsers](https://eslint.org/docs/developer-guide/working-with-custom-parsers)
    * @see [Specifying Parser](https://eslint.org/docs/user-guide/configuring/plugins#specifying-parser)
    */
-  parser?: Parser;
+  parser?: Parser | Record<string, string | Parser>;
 
   /**
    * This option allows you to provide a path to your project's `tsconfig.json`.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Extend parser definition in parserOptions for use espree <template> like [vue-eslint-plugin](https://github.com/vuejs/vue-eslint-parser#parseroptionsparser) prodiveds.

### Linked Issues

For [#294](https://github.com/antfu/eslint-config/issues/294) in @antfu/eslint-config